### PR TITLE
Fixed numVisibleItems in Scroller component

### DIFF
--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -256,7 +256,7 @@ export default class CalendarScroller extends Component {
   onLayout = event => {
     let width = event.nativeEvent.layout.width;
     this.setState({
-      numVisibleItems: Math.floor(width / this.state.itemWidth),
+      numVisibleItems: Math.round(width / this.state.itemWidth),
     });
   }
 


### PR DESCRIPTION
I got the case when `numVisibleItems` is calculated as 6 instead of 7 days and that is ruins paged scrollable. I found that before `Math.floor()` being applied the raw value is 6.94 which, I believe, is ok since it's calculated upon rounded `itemWidth` & `marginHorizontal` values. But when you floor the `numVisibleItems` itself it ends up in wrong days & unexpected paging behavior. This PR suggests to replace `Math.floor()` with `Math.round()`

I suppose it also could be a fix for issue #269